### PR TITLE
Restrict orientation to portrait mode only

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.github.hamzaahmedkhan">
+        package="com.github.hamzaahmedkhan">
 
     <application
             android:allowBackup="true"
@@ -9,11 +9,13 @@
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity
+                android:name=".MainActivity"
+                android:screenOrientation="portrait">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>


### PR DESCRIPTION
The search results got disappeared if the user switches their device orientation to the landscape that's why I have restricted to portrait mode only. Kindly do the handling of data retention that has to be survived on change orientation. I would recommend to use ViewModel for data presentation. 